### PR TITLE
Fixes bug where reverse_geocode options were overriding geocode options

### DIFF
--- a/lib/sequel-geocoder/class_methods.rb
+++ b/lib/sequel-geocoder/class_methods.rb
@@ -28,7 +28,8 @@ module Sequel::Plugins::Geocoder
 
     private
     def geocoder_init(options)
-      dataset.geocoder_options = options
+      dataset.geocoder_options ||= {}
+      dataset.geocoder_options.merge! options
     end
   end
 end


### PR DESCRIPTION
Prevents reverse_geocoded_by from overriding options set by geocoded_by and vice versa 
